### PR TITLE
Update RecurrenceHelper.cs

### DIFF
--- a/Parse_Recurrece_Rule/ScheduleSample/Models/RecurrenceHelper.cs
+++ b/Parse_Recurrece_Rule/ScheduleSample/Models/RecurrenceHelper.cs
@@ -78,6 +78,10 @@ namespace ScheduleSample
             {
                 FindExdateList(RecException);
             }
+            if (exDateList.Contains(RecStartDate.Date))
+            {
+                return new List<DateTime> { RecStartDate.Date };
+            }
             if (ruleArray.Length != 0 && RRule != "")
             {
                 DateTime addDate = startDate;
@@ -87,7 +91,7 @@ namespace ScheduleSample
                 #region DAILY
                 if (DAILY == "DAILY")
                 {
-
+                
                     if ((ruleArray.Length > 4 && INTERVAL == "INTERVAL") || ruleArray.Length == 4)
                     {
                         int DyDayGap = ruleArray.Length == 4 ? 1 : int.Parse(INTERVALCOUNT);


### PR DESCRIPTION
This class doesn't work properly when a particular instance of a recurring event is updated.

Adding this check returns just the current date if it exists on the exception list (being on this list means that it is a one-day event which is part of some recurring event, but that particular instance was udpated)

Without this, such an updated event will return all instances of the recurrence, which is wrong (as that instance may have a different start/end date, subject, location etc)